### PR TITLE
revert: change the z-index of the header

### DIFF
--- a/src/styles/overrides.scss
+++ b/src/styles/overrides.scss
@@ -65,7 +65,7 @@
 }
 
 .pc-navigation {
-    z-index:  1050;
+    z-index:  101;
 
     .desktop .dc-root_wide-format & .container-fluid {
         padding: 0;
@@ -105,7 +105,7 @@
 }
 
 .pc-navigation {
-    z-index:  1050;
+    z-index:  101;
 
     .desktop.dc-root_wide-format & .container-fluid {
         padding: 30px;


### PR DESCRIPTION
Reverts diplodoc-platform/client#51

After changing the z-index of the header, a new problem appeared related to the controls on the desktop. 
It was decided to revert PR. 

And to solve the initial problem, the z-index in terms will be changed to a lower value than it is now 
(100 instead of 1000)

ef6292e6805fa04b1e55b5b0d0f8f3aa888d0060