### PR TITLE
Implement Search

### DIFF
--- a/src/components/App/Page.tsx
+++ b/src/components/App/Page.tsx
@@ -71,7 +71,7 @@ export function RichNavPage({data, props, controls}: PageProps<WithNavigation>) 
 
     const CustomSuggest = useCallback(() => <Suggest />, []);
     const CustomControls = useCallback(() => <HeaderControls {...controls} />, [controls]);
-    const navigation = useNavigation(data, CustomControls, CustomSuggest);
+    const navigation = useNavigation(data, controls, CustomControls, CustomSuggest);
 
     const CustomPage = useCallback(
         () => (

--- a/src/components/ConstructorPage/useNavigation.tsx
+++ b/src/components/ConstructorPage/useNavigation.tsx
@@ -2,15 +2,19 @@ import type {ReactNode} from 'react';
 import type {NavigationData} from '@gravity-ui/page-constructor';
 import type {DocBasePageData} from '@diplodoc/components';
 import type {WithNavigation} from '../App';
+import type {Props as HeaderControlsProps} from '../HeaderControls';
 
 import React, {useMemo} from 'react';
 import {ControlSizes, CustomNavigation, MobileDropdown} from '@diplodoc/components';
 
 import {HEADER_HEIGHT} from '../../constants';
+import {useRouter} from '../';
 
 export const useNavigation = (
     data: DocBasePageData<WithNavigation>,
+    controls: HeaderControlsProps,
     CustomControls: () => ReactNode,
+    CustomSuggest: () => ReactNode,
 ) => {
     const {toc} = data;
     const {navigation} = toc;
@@ -20,7 +24,6 @@ export const useNavigation = (
     const withControls = rightItems.some((item: {type: string}) => item.type === 'controls');
 
     const router = useRouter();
-    const userSettings = useSettings();
 
     const navigationData = useMemo(
         () => ({
@@ -41,9 +44,9 @@ export const useNavigation = (
     const mobileControlsData = useMemo(
         () => ({
             controlSize: ControlSizes.L,
-            userSettings,
+            userSettings: controls,
         }),
-        [userSettings],
+        [controls],
     );
 
     const layout = useMemo(
@@ -67,13 +70,14 @@ export const useNavigation = (
     const config = useMemo(
         () => ({
             custom: {
+                search: CustomSuggest,
                 controls: CustomControls,
                 MobileDropdown: MobileDropdown,
             },
             layout,
             withControls,
         }),
-        [CustomControls, layout, withControls],
+        [CustomSuggest, CustomControls, layout, withControls],
     );
 
     return config;

--- a/src/components/Router/index.ts
+++ b/src/components/Router/index.ts
@@ -1,0 +1,20 @@
+import type {Router} from '@diplodoc/components';
+
+import {createContext, useContext} from 'react';
+
+export interface RouterConfig extends Router {
+    depth: number;
+}
+
+export const RouterContext = createContext<RouterConfig>({
+    pathname: '/',
+    depth: 0,
+});
+
+RouterContext.displayName = 'RouterContext';
+
+export const RouterProvider = RouterContext.Provider;
+
+export function useRouter() {
+    return useContext(RouterContext);
+}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const Search = () => {
+    return <div>Initial</div>;
+};

--- a/src/components/Search/Suggest.scss
+++ b/src/components/Search/Suggest.scss
@@ -1,0 +1,17 @@
+.Suggest {
+    margin-right: 20px;
+    min-width: 200px;
+    transition: min-width 0.3s;
+
+    .dc-root_focused-search & {
+        min-width: 500px;
+    }
+
+    &__Item {
+        &__Marker {
+            background: var(--g-color-base-neutral-medium);
+            padding: 0 3px 1px;
+            border-radius: 4px;
+        }
+    }
+}

--- a/src/components/Search/Suggest.tsx
+++ b/src/components/Search/Suggest.tsx
@@ -1,0 +1,41 @@
+import type {ISearchProvider, SearchSuggestApi} from '@diplodoc/components';
+
+import React, {useCallback, useRef} from 'react';
+import {SearchSuggest} from '@diplodoc/components';
+
+import {updateRootClassName} from '../../utils';
+
+import {useProvider} from './useProvider';
+import './Suggest.scss';
+
+export function Suggest() {
+    const provider: ISearchProvider | null = useProvider();
+    const suggest = useRef<SearchSuggestApi>(null);
+
+    const onFocus = useCallback(() => {
+        updateRootClassName({focusSearch: true});
+    }, []);
+
+    const onBlur = useCallback(() => {
+        updateRootClassName({focusSearch: false});
+        setTimeout(() => {
+            if (suggest.current) {
+                suggest.current.close();
+            }
+        }, 100);
+    }, []);
+
+    if (!provider) {
+        return null;
+    }
+
+    return (
+        <SearchSuggest
+            ref={suggest}
+            provider={provider}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            classNameContainer={'Suggest'}
+        />
+    );
+}

--- a/src/components/Search/index.ts
+++ b/src/components/Search/index.ts
@@ -1,0 +1,13 @@
+import type {SearchConfig, WorkerApi, WorkerConfig} from './types';
+
+import {createContext} from 'react';
+
+export type {SearchConfig, WorkerConfig, WorkerApi};
+
+export const SearchContext = createContext<SearchConfig | null | undefined>(null);
+
+SearchContext.displayName = 'SearchContext';
+
+export const SearchProvider = SearchContext.Provider;
+
+export {Search} from './Search';

--- a/src/components/Search/provider/index.ts
+++ b/src/components/Search/provider/index.ts
@@ -1,0 +1,86 @@
+import type {ISearchProvider, ISearchResult} from '@diplodoc/components';
+import type {SearchConfig, WorkerConfig} from '../types';
+
+export class SearchProvider implements ISearchProvider {
+    private worker!: Promise<Worker>;
+
+    private config: SearchConfig;
+
+    constructor(config: SearchConfig) {
+        this.config = config;
+    }
+
+    init = () => {
+        this.worker = initWorker({
+            ...this.config,
+            base: this.base,
+            mark: 'Suggest__Item__Marker',
+        });
+    };
+
+    async suggest(query: string) {
+        return this.request({
+            type: 'suggest',
+            query,
+        }) as Promise<ISearchResult[]>;
+    }
+
+    async search(query: string) {
+        return this.request({
+            type: 'search',
+            query,
+        }) as Promise<ISearchResult[]>;
+    }
+
+    // Temporary disable link to search page
+    // TODO: Implement search page
+    link = () => null;
+
+    // link = (query: string) => {
+    //     const params = query ? `?query=${encodeURIComponent(query)}` : '';
+    //
+    //     return `${this.base}/${this.config.link}${params}`;
+    // };
+
+    private get base() {
+        return window.location.pathname
+            .split('/')
+            .slice(0, -(this.config.depth + 1))
+            .join('/');
+    }
+
+    private async request(message: object) {
+        return request(await this.worker, message);
+    }
+}
+
+async function initWorker(config: WorkerConfig) {
+    const worker = new Worker(new URL('../worker/index.ts', import.meta.url));
+
+    await request(worker, {...config, type: 'init'});
+
+    return worker;
+}
+
+function request(worker: Worker, message: object) {
+    const channel = new MessageChannel();
+
+    return new Promise((resolve, reject) => {
+        channel.port1.onmessage = (message) => {
+            if (message.data.error) {
+                // eslint-disable-next-line no-console
+                console.error(message.data.error);
+
+                reject(message.data.error);
+            } else {
+                resolve(message.data.result);
+            }
+        };
+
+        channel.port1.onmessageerror = (message) => {
+            reject(message.data.error);
+        };
+
+        worker.postMessage(message, [channel.port2]);
+    });
+}

--- a/src/components/Search/types.ts
+++ b/src/components/Search/types.ts
@@ -1,0 +1,41 @@
+import {SearchSuggestPageItem} from '@diplodoc/components';
+
+export interface SearchConfig {
+    api: string;
+    link: string;
+    lang: string;
+    depth: number;
+}
+
+export interface WorkerConfig {
+    api: string;
+    base: string;
+    mark: string;
+}
+
+export interface WorkerApi {
+    init?(): void | Promise<void>;
+    suggest(query: string, count: number): Promise<SearchSuggestPageItem[]>;
+    search(query: string, count: number, page: number): Promise<SearchSuggestPageItem[]>;
+}
+
+export type InitMessage = {
+    type: 'init';
+} & WorkerConfig;
+
+export type SuggestMessage = {
+    type: 'suggest';
+    query: string;
+    count?: number;
+};
+
+export type SearchMessage = {
+    type: 'search';
+    query: string;
+    page?: number;
+    count?: number;
+};
+
+export type Message = InitMessage | SuggestMessage | SearchMessage;
+
+export type MessageType = Message['type'];

--- a/src/components/Search/useProvider.ts
+++ b/src/components/Search/useProvider.ts
@@ -1,0 +1,24 @@
+import {useContext, useMemo} from 'react';
+
+import {RouterContext, SearchContext} from '../index';
+import {useLang} from '../../hooks/useLang';
+
+import {SearchProvider} from './provider';
+
+export function useProvider() {
+    const lang = useLang();
+    const {depth = 0} = useContext(RouterContext);
+    const search = useContext(SearchContext);
+
+    return useMemo(() => {
+        if (!search) {
+            return null;
+        }
+
+        return new SearchProvider({
+            ...search,
+            depth,
+            lang,
+        });
+    }, [lang, depth, search]);
+}

--- a/src/components/Search/worker/index.ts
+++ b/src/components/Search/worker/index.ts
@@ -1,0 +1,89 @@
+/// <reference no-default-lib="true"/>
+/// <reference lib="ES2015" />
+/// <reference lib="webworker" />
+
+/* eslint-disable new-cap */
+import type {
+    InitMessage,
+    MessageType,
+    SearchMessage,
+    SuggestMessage,
+    WorkerApi,
+    WorkerConfig,
+} from '../types';
+
+// Default type of `self` is `WorkerGlobalScope & typeof globalThis`
+// https://github.com/microsoft/TypeScript/issues/14877
+declare const self: ServiceWorkerGlobalScope & {
+    config?: WorkerConfig;
+    api?: WorkerApi;
+};
+
+const UNKNOWN_HANDLER = {
+    message: 'Unknown message type!',
+    code: 'UNKNOWN_HANDLER',
+};
+const NOT_INITIALIZED_CONFIG = {
+    message: 'Worker is not initialized with required config!',
+    code: 'NOT_INITIALIZED',
+};
+const NOT_INITIALIZED_API = {
+    message: 'Worker is not initialized with required api!',
+    code: 'NOT_INITIALIZED',
+};
+
+export function AssertConfig(config: unknown): asserts config is WorkerConfig {
+    if (!config) {
+        throw NOT_INITIALIZED_CONFIG;
+    }
+}
+
+export function AssertApi(api: unknown): asserts api is WorkerApi {
+    if (!api) {
+        throw NOT_INITIALIZED_API;
+    }
+}
+
+const HANDLERS = {
+    async init(config: InitMessage) {
+        self.config = config;
+
+        importScripts(self.config.api);
+
+        AssertApi(self.api);
+
+        return self.api.init?.();
+    },
+
+    async suggest({query, count = 10}: SuggestMessage) {
+        AssertConfig(self.config);
+        AssertApi(self.api);
+
+        return self.api.suggest(query, count);
+    },
+
+    async search({query, count = 10, page = 1}: SearchMessage) {
+        AssertConfig(self.config);
+        AssertApi(self.api);
+
+        return self.api.search(query, count, page);
+    },
+} as const;
+
+self.onmessage = async (message) => {
+    const [port] = message.ports;
+    const {type} = message.data;
+
+    const handler = HANDLERS[type as MessageType];
+    if (!handler) {
+        port.postMessage({error: UNKNOWN_HANDLER});
+    }
+
+    try {
+        const result = await handler(message.data);
+
+        port.postMessage({result});
+    } catch (error) {
+        port.postMessage({error});
+    }
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export {SearchContext, SearchProvider} from './Search';
+export {RouterContext, RouterProvider, useRouter} from './Router';
+
+export {App} from './App';

--- a/src/index.server.tsx
+++ b/src/index.server.tsx
@@ -6,6 +6,11 @@ import {LINK_KEYS, LINK_KEYS_LEADING_CONFIG, LINK_KEYS_PAGE_CONSTRUCTOR_CONFIG} 
 import {preprocess} from './preprocess';
 
 export type {DocInnerProps, DocPageData, DocLeadingPageData, DocAnalytics};
+export type {
+    SearchConfig as ISearchProviderConfig,
+    WorkerConfig as ISearchWorkerConfig,
+    WorkerApi as ISearchWorkerApi,
+} from './components/Search';
 export {LINK_KEYS, LINK_KEYS_LEADING_CONFIG, LINK_KEYS_PAGE_CONSTRUCTOR_CONFIG, preprocess};
 
 export const render = (props: DocInnerProps) => renderToString(<App {...props} />);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,11 @@ import {createRoot, hydrateRoot} from 'react-dom/client';
 import {App, DocAnalytics, DocInnerProps, DocLeadingPageData, DocPageData} from './components/App';
 
 export type {DocInnerProps, DocPageData, DocLeadingPageData, DocAnalytics};
+export type {
+    SearchConfig as ISearchProviderConfig,
+    WorkerConfig as ISearchWorkerConfig,
+    WorkerApi as ISearchWorkerApi,
+} from './components/Search';
 
 declare global {
     interface Window {

--- a/src/search.tsx
+++ b/src/search.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import {createRoot} from 'react-dom/client';
+
+import {Search} from './components/Search';
+
+const root = document.getElementById('root');
+
+if (!root) {
+    throw new Error('Root element not found!');
+}
+
+createRoot(root).render(<Search />);


### PR DESCRIPTION
**Concepts:**

- Add a local Suggest component. This is a wrapper around @diplodoc/components/Suggest.
- Implement SearchProvider, which should be passed to the Suggest component.
- The SearchProvider consists of two parts: a suggest adapter connected to the suggest component, and an isolated worker runtime where the main search algorithm should be implemented.
- The worker itself does not contain any implemented search algorithms, and tries to load them from an external resource using the `importScripts` API.
- Build output manifest adopted to new reality, with additional async worker module and new search entry.