### PR TITLE
fix: save theme settings in localstorage avoid session storage

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,10 @@ export const HEADER_HEIGHT = 64;
 
 export const MOBILE_VIEW_WIDTH_BREAKPOINT = 769;
 
+export const LOCAL_STORAGE_SETTING = {
+    theme: 'theme',
+} as const;
+
 export const DEFAULT_USER_SETTINGS = {
     theme: Theme.Light,
     textSize: TextSizes.M,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -115,10 +115,10 @@ function getSetting<T extends keyof Settings>(name: T): Settings[T] {
 
     try {
         if (name === LOCAL_STORAGE_SETTING.theme) {
-            return (sessionStorage.getItem(name) as Settings[T]) || DEFAULT_USER_SETTINGS[name];
+            return (localStorage.getItem(name) as Settings[T]) || DEFAULT_USER_SETTINGS[name];
         }
 
-        return (localStorage.getItem(name) as Settings[T]) || DEFAULT_USER_SETTINGS[name];
+        return (sessionStorage.getItem(name) as Settings[T]) || DEFAULT_USER_SETTINGS[name];
     } catch {
         return DEFAULT_USER_SETTINGS[name];
     }
@@ -131,9 +131,9 @@ export function setSetting<T>(name: string, value: T) {
 
     try {
         if (name === LOCAL_STORAGE_SETTING.theme) {
-            sessionStorage.setItem(name, String(value));
-        } else {
             localStorage.setItem(name, String(value));
+        } else {
+            sessionStorage.setItem(name, String(value));
         }
     } catch {}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import {Lang, Theme, getPageType} from '@diplodoc/components';
 
 import {
     DEFAULT_USER_SETTINGS,
+    LOCAL_STORAGE_SETTING,
     MOBILE_VIEW_WIDTH_BREAKPOINT,
     RTL_LANGS,
     TextDirection,
@@ -113,7 +114,11 @@ function getSetting<T extends keyof Settings>(name: T): Settings[T] {
     }
 
     try {
-        return (sessionStorage.getItem(name) as Settings[T]) || DEFAULT_USER_SETTINGS[name];
+        if (name === LOCAL_STORAGE_SETTING.theme) {
+            return (sessionStorage.getItem(name) as Settings[T]) || DEFAULT_USER_SETTINGS[name];
+        }
+
+        return (localStorage.getItem(name) as Settings[T]) || DEFAULT_USER_SETTINGS[name];
     } catch {
         return DEFAULT_USER_SETTINGS[name];
     }
@@ -125,6 +130,10 @@ export function setSetting<T>(name: string, value: T) {
     }
 
     try {
-        sessionStorage.setItem(name, String(value));
+        if (name === LOCAL_STORAGE_SETTING.theme) {
+            sessionStorage.setItem(name, String(value));
+        } else {
+            localStorage.setItem(name, String(value));
+        }
     } catch {}
 }


### PR DESCRIPTION
The name of the property for LocalStorage is made into a constant. in the reading/saving functions, a check by field name and a choice of where to save the settings have been added
