### PR TITLE
chore: speedup webpack twice

### DIFF
--- a/webpack/config.js
+++ b/webpack/config.js
@@ -3,20 +3,6 @@ const {DefinePlugin} = require('webpack');
 const MiniCSSExtractPlugin = require('mini-css-extract-plugin');
 const {WebpackManifestPlugin} = require('webpack-manifest-plugin');
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
-const threadLoader = require('thread-loader');
-
-threadLoader.warmup(
-    {
-        // pool options, like passed to loader options
-        // must match loader options to boot the correct pool
-    },
-    [
-        // modules to load
-        // can be any module, i. e.
-        'babel-loader',
-        'sass-loader',
-    ],
-);
 
 const RtlCssPlugin = require('./rtl-css');
 
@@ -188,7 +174,7 @@ function config({isServer, isDev, analyze = false}) {
             rules: [
                 {
                     test: /\.[tj]sx?$/,
-                    use: ['thread-loader', 'babel-loader'],
+                    use: ['babel-loader'],
                     include: [src(), require.resolve('@diplodoc/mermaid-extension')],
                 },
                 {

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -203,3 +203,5 @@ module.exports = [
     config({isServer: false, isDev: process.env.NODE_ENV === 'development'}),
     config({isServer: true, isDev: process.env.NODE_ENV === 'development'}),
 ];
+
+module.exports.parallelism = 1;

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -3,6 +3,20 @@ const {DefinePlugin} = require('webpack');
 const MiniCSSExtractPlugin = require('mini-css-extract-plugin');
 const {WebpackManifestPlugin} = require('webpack-manifest-plugin');
 const {BundleAnalyzerPlugin} = require('webpack-bundle-analyzer');
+const threadLoader = require('thread-loader');
+
+threadLoader.warmup(
+    {
+        // pool options, like passed to loader options
+        // must match loader options to boot the correct pool
+    },
+    [
+        // modules to load
+        // can be any module, i. e.
+        'babel-loader',
+        'sass-loader',
+    ],
+);
 
 const RtlCssPlugin = require('./rtl-css');
 
@@ -174,7 +188,7 @@ function config({isServer, isDev, analyze = false}) {
             rules: [
                 {
                     test: /\.[tj]sx?$/,
-                    use: ['babel-loader'],
+                    use: ['thread-loader', 'babel-loader'],
                     include: [src(), require.resolve('@diplodoc/mermaid-extension')],
                 },
                 {
@@ -204,4 +218,9 @@ module.exports = [
     config({isServer: true, isDev: process.env.NODE_ENV === 'development'}),
 ];
 
+/*
+    https://webpack.js.org/configuration/configuration-types/#parallelism
+    1 = parallel compilation for >1 configs (example: server, client)
+    made for twice speed boost
+*/
 module.exports.parallelism = 1;


### PR DESCRIPTION
webpack optimization on client

до: webpack 5.98.0 compiled successfully in 10490 ms



после: webpack 5.98.0 compiled successfully in 4458 ms


https://webpack.js.org/configuration/configuration-types/#parallelism
    1 = parallel compilation for >1 configs (example: server, client)
    made for twice speed boost