### PR TITLE
fix: changed cursor to zoom-in for img and svg

### DIFF
--- a/src/styles/overrides.scss
+++ b/src/styles/overrides.scss
@@ -54,19 +54,6 @@
     &__main:has(&__content > .pc-page-constructor__docs) {
         padding: 20px 0 24px;
     }
-
-    &__main {
-        img {
-            &:not(
-                .dc-contributor-avatars__avatar img,
-                [class*='background'] img,
-                [class^='icon' i] img,
-                [class*='icon' i] img
-            ) {
-                cursor: pointer;
-            }
-        }
-    }
 }
 
 .pc-desktop-navigation {


### PR DESCRIPTION
Changed cursor interactions with content images and SVGs inside the documentation page from pointer to zoom-in

It also ensures that any system elements, and images, SVGs wrapped in anchor () tags are strictly excluded from the zoom cursor to preserve native link behavior.